### PR TITLE
Add GitHub action to publish the workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,32 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: Build workflow
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+          check-latest: true
+          cache: true
+      - name: Build binaries
+        run: |
+          GOOS=darwin GOARCH=arm64 go build -o dictcc_arm64 main.go
+          GOOS=darwin GOARCH=amd64 go build -o dictcc_amd64 main.go
+      - name: Bundle workflow
+        run: |
+          mkdir dist
+          zip dist/Dict.cc.alfredworkflow dictcc_arm64 dictcc_amd64 assets/info.plist assets/icon.png
+      - name: Create or update the GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/Dict.cc.alfredworkflow

--- a/assets/info.plist
+++ b/assets/info.plist
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>bundleid</key>
+	<string>universal.dict.cc</string>
+	<key>connections</key>
+	<dict>
+		<key>230B7E17-DE58-409D-821F-A8F7228E7B6D</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>BD993DCC-6A60-4320-903E-EF147BC55589</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>64D310B5-3CCA-4CC5-B216-B8D58A59C070</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>F1000F74-5759-4CCD-9340-87037FA12234</string>
+				<key>modifiers</key>
+				<integer>524288</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>177877D7-B9C6-4769-B88B-D310CE841A9C</string>
+				<key>modifiers</key>
+				<integer>1048576</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+	</dict>
+	<key>createdby</key>
+	<string>Dennis Trautwein</string>
+	<key>description</key>
+	<string>Online Dictionary</string>
+	<key>disabled</key>
+	<false/>
+	<key>name</key>
+	<string>Dict.cc</string>
+	<key>objects</key>
+	<array>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>autopaste</key>
+				<false/>
+				<key>clipboardtext</key>
+				<string></string>
+				<key>ignoredynamicplaceholders</key>
+				<false/>
+				<key>transient</key>
+				<false/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.output.clipboard</string>
+			<key>uid</key>
+			<string>BD993DCC-6A60-4320-903E-EF147BC55589</string>
+			<key>version</key>
+			<integer>3</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>lastpathcomponent</key>
+				<false/>
+				<key>onlyshowifquerypopulated</key>
+				<false/>
+				<key>removeextension</key>
+				<false/>
+				<key>text</key>
+				<string>Copied "{query}" to clipboard</string>
+				<key>title</key>
+				<string>dict.cc</string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.output.notification</string>
+			<key>uid</key>
+			<string>64D310B5-3CCA-4CC5-B216-B8D58A59C070</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>alfredfiltersresults</key>
+				<false/>
+				<key>alfredfiltersresultsmatchmode</key>
+				<integer>0</integer>
+				<key>argumenttreatemptyqueryasnil</key>
+				<false/>
+				<key>argumenttrimmode</key>
+				<integer>0</integer>
+				<key>argumenttype</key>
+				<integer>0</integer>
+				<key>escaping</key>
+				<integer>126</integer>
+				<key>keyword</key>
+				<string>dict</string>
+				<key>queuedelaycustom</key>
+				<integer>3</integer>
+				<key>queuedelayimmediatelyinitially</key>
+				<false/>
+				<key>queuedelaymode</key>
+				<integer>1</integer>
+				<key>queuemode</key>
+				<integer>2</integer>
+				<key>runningsubtext</key>
+				<string>Please wait...</string>
+				<key>script</key>
+				<string>QUERY=$(iconv -f UTF8-MAC &lt;&lt;&lt;'{query}')
+
+# Check for Apple Silicon
+if [[ $(uname -m) == 'arm64' ]]; then
+  ./dictcc_arm64 "$QUERY"
+else
+  ./dictcc_amd64 "$QUERY"
+fi</string>
+				<key>scriptargtype</key>
+				<integer>0</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>subtext</key>
+				<string>[eng, ger, fra, swe, esp, buk, rom, ita, por, rus]</string>
+				<key>title</key>
+				<string>Translate...</string>
+				<key>type</key>
+				<integer>0</integer>
+				<key>withspace</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.input.scriptfilter</string>
+			<key>uid</key>
+			<string>230B7E17-DE58-409D-821F-A8F7228E7B6D</string>
+			<key>version</key>
+			<integer>3</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>browser</key>
+				<string></string>
+				<key>spaces</key>
+				<string></string>
+				<key>url</key>
+				<string></string>
+				<key>utf8</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.openurl</string>
+			<key>uid</key>
+			<string>F1000F74-5759-4CCD-9340-87037FA12234</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>browser</key>
+				<string></string>
+				<key>spaces</key>
+				<string></string>
+				<key>url</key>
+				<string></string>
+				<key>utf8</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.openurl</string>
+			<key>uid</key>
+			<string>177877D7-B9C6-4769-B88B-D310CE841A9C</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+	</array>
+	<key>readme</key>
+	<string>Alfred workflow to get bidirectional translations from dict.cc.
+
+
+If this workflow saves you time you may consider to buy me a coffee :)
+
+https://www.buymeacoffee.com/dennistra</string>
+	<key>uidata</key>
+	<dict>
+		<key>177877D7-B9C6-4769-B88B-D310CE841A9C</key>
+		<dict>
+			<key>xpos</key>
+			<integer>510</integer>
+			<key>ypos</key>
+			<integer>540</integer>
+		</dict>
+		<key>230B7E17-DE58-409D-821F-A8F7228E7B6D</key>
+		<dict>
+			<key>xpos</key>
+			<integer>240</integer>
+			<key>ypos</key>
+			<integer>360</integer>
+		</dict>
+		<key>64D310B5-3CCA-4CC5-B216-B8D58A59C070</key>
+		<dict>
+			<key>xpos</key>
+			<integer>510</integer>
+			<key>ypos</key>
+			<integer>300</integer>
+		</dict>
+		<key>BD993DCC-6A60-4320-903E-EF147BC55589</key>
+		<dict>
+			<key>xpos</key>
+			<integer>510</integer>
+			<key>ypos</key>
+			<integer>180</integer>
+		</dict>
+		<key>F1000F74-5759-4CCD-9340-87037FA12234</key>
+		<dict>
+			<key>xpos</key>
+			<integer>510</integer>
+			<key>ypos</key>
+			<integer>420</integer>
+		</dict>
+	</dict>
+	<key>variables</key>
+	<dict>
+		<key>from_language</key>
+		<string></string>
+		<key>to_language</key>
+		<string></string>
+	</dict>
+	<key>variablesdontexport</key>
+	<array/>
+	<key>version</key>
+	<string>2.0.0</string>
+	<key>webaddress</key>
+	<string>https://github.com/dennis-tra/alfred-dict.cc-workflow</string>
+</dict>
+</plist>

--- a/assets/info.plist
+++ b/assets/info.plist
@@ -6,6 +6,19 @@
 	<string>universal.dict.cc</string>
 	<key>connections</key>
 	<dict>
+		<key>1F149DD5-76CD-4ABE-81F4-2EF6FEDF2EC3</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>230B7E17-DE58-409D-821F-A8F7228E7B6D</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
 		<key>230B7E17-DE58-409D-821F-A8F7228E7B6D</key>
 		<array>
 			<dict>
@@ -49,6 +62,32 @@
 				<false/>
 			</dict>
 		</array>
+		<key>5FA0111C-4F93-4183-8AD5-73496AC4C857</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>230B7E17-DE58-409D-821F-A8F7228E7B6D</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>AAF93BF2-1C2C-4D19-933F-5B3A07747BD2</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>230B7E17-DE58-409D-821F-A8F7228E7B6D</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
 	</dict>
 	<key>createdby</key>
 	<string>Dennis Trautwein</string>
@@ -78,6 +117,37 @@
 			<string>BD993DCC-6A60-4320-903E-EF147BC55589</string>
 			<key>version</key>
 			<integer>3</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>action</key>
+				<integer>0</integer>
+				<key>argument</key>
+				<integer>1</integer>
+				<key>focusedappvariable</key>
+				<false/>
+				<key>focusedappvariablename</key>
+				<string></string>
+				<key>hotkey</key>
+				<integer>0</integer>
+				<key>hotmod</key>
+				<integer>0</integer>
+				<key>hotstring</key>
+				<string></string>
+				<key>leftcursor</key>
+				<false/>
+				<key>modsmode</key>
+				<integer>0</integer>
+				<key>relatedAppsMode</key>
+				<integer>0</integer>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.trigger.hotkey</string>
+			<key>uid</key>
+			<string>AAF93BF2-1C2C-4D19-933F-5B3A07747BD2</string>
+			<key>version</key>
+			<integer>2</integer>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -159,6 +229,27 @@ fi</string>
 		<dict>
 			<key>config</key>
 			<dict>
+				<key>acceptsfiles</key>
+				<true/>
+				<key>acceptsmulti</key>
+				<integer>0</integer>
+				<key>acceptstext</key>
+				<true/>
+				<key>acceptsurls</key>
+				<true/>
+				<key>name</key>
+				<string>Translate</string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.trigger.universalaction</string>
+			<key>uid</key>
+			<string>5FA0111C-4F93-4183-8AD5-73496AC4C857</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
 				<key>browser</key>
 				<string></string>
 				<key>spaces</key>
@@ -174,6 +265,37 @@ fi</string>
 			<string>F1000F74-5759-4CCD-9340-87037FA12234</string>
 			<key>version</key>
 			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>action</key>
+				<integer>0</integer>
+				<key>argument</key>
+				<integer>2</integer>
+				<key>focusedappvariable</key>
+				<false/>
+				<key>focusedappvariablename</key>
+				<string></string>
+				<key>hotkey</key>
+				<integer>0</integer>
+				<key>hotmod</key>
+				<integer>0</integer>
+				<key>hotstring</key>
+				<string></string>
+				<key>leftcursor</key>
+				<false/>
+				<key>modsmode</key>
+				<integer>0</integer>
+				<key>relatedAppsMode</key>
+				<integer>0</integer>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.trigger.hotkey</string>
+			<key>uid</key>
+			<string>1F149DD5-76CD-4ABE-81F4-2EF6FEDF2EC3</string>
+			<key>version</key>
+			<integer>2</integer>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -207,45 +329,68 @@ https://www.buymeacoffee.com/dennistra</string>
 		<key>177877D7-B9C6-4769-B88B-D310CE841A9C</key>
 		<dict>
 			<key>xpos</key>
-			<integer>510</integer>
+			<real>510</real>
 			<key>ypos</key>
-			<integer>540</integer>
+			<real>540</real>
+		</dict>
+		<key>1F149DD5-76CD-4ABE-81F4-2EF6FEDF2EC3</key>
+		<dict>
+			<key>xpos</key>
+			<real>50</real>
+			<key>ypos</key>
+			<real>490</real>
 		</dict>
 		<key>230B7E17-DE58-409D-821F-A8F7228E7B6D</key>
 		<dict>
 			<key>xpos</key>
-			<integer>240</integer>
+			<real>240</real>
 			<key>ypos</key>
-			<integer>360</integer>
+			<real>360</real>
+		</dict>
+		<key>5FA0111C-4F93-4183-8AD5-73496AC4C857</key>
+		<dict>
+			<key>xpos</key>
+			<real>50</real>
+			<key>ypos</key>
+			<real>365</real>
 		</dict>
 		<key>64D310B5-3CCA-4CC5-B216-B8D58A59C070</key>
 		<dict>
 			<key>xpos</key>
-			<integer>510</integer>
+			<real>510</real>
 			<key>ypos</key>
-			<integer>300</integer>
+			<real>300</real>
+		</dict>
+		<key>AAF93BF2-1C2C-4D19-933F-5B3A07747BD2</key>
+		<dict>
+			<key>xpos</key>
+			<real>45</real>
+			<key>ypos</key>
+			<real>235</real>
 		</dict>
 		<key>BD993DCC-6A60-4320-903E-EF147BC55589</key>
 		<dict>
 			<key>xpos</key>
-			<integer>510</integer>
+			<real>510</real>
 			<key>ypos</key>
-			<integer>180</integer>
+			<real>180</real>
 		</dict>
 		<key>F1000F74-5759-4CCD-9340-87037FA12234</key>
 		<dict>
 			<key>xpos</key>
-			<integer>510</integer>
+			<real>510</real>
 			<key>ypos</key>
-			<integer>420</integer>
+			<real>420</real>
 		</dict>
 	</dict>
+	<key>userconfigurationconfig</key>
+	<array/>
 	<key>variables</key>
 	<dict>
 		<key>from_language</key>
-		<string></string>
+		<string>de</string>
 		<key>to_language</key>
-		<string></string>
+		<string>en</string>
 	</dict>
 	<key>variablesdontexport</key>
 	<array/>


### PR DESCRIPTION
This adds a GitHub action to build and release the workflow whenever a
tag is pushed that looks like a semver tag.

When a release with a corresponding tag is created through the GitHub
interface, this action runs. It builds and packages the workflow and
then adds the workflow to the existing GitHub release.

If a tag is pushed, but no GitHub release exists, it creates a new one.
The title is going to be the pushed tag and the body the commit message
of the commit the tag points to.

Also contains changes from #13, which needs to be merged first (or at least
the addition of the `info.plist` to the repo). Relevant changes in this PR in
9b47b5b. The other two commits are from #13.

Relates to: #12
Relates to: #13